### PR TITLE
Ajuste na integração com os correios pra usar a versão atualizada de Correios-Frete

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ PATH
   remote: .
   specs:
     spree_correios (1.0.5)
-      correios-frete (~> 1.11.1)
+      correios-frete (= 1.12.0)
       spree_core (>= 3.2.0)
 
 GEM

--- a/app/models/spree/calculator/pac.rb
+++ b/app/models/spree/calculator/pac.rb
@@ -6,7 +6,7 @@ module Spree
     
     def shipping_method
       if has_contract?
-        :pac_com_contrato
+        :pac_com_contrato_2
       else
         :pac
       end
@@ -14,9 +14,9 @@ module Spree
     
     def shipping_code
       if has_contract?
-        41068
+        '04669'
       else
-        41106
+        '41106'
       end
     end
   end

--- a/app/models/spree/calculator/sedex.rb
+++ b/app/models/spree/calculator/sedex.rb
@@ -5,8 +5,8 @@ module Spree
     end
     
     def shipping_method
-      if preferred_token.present? && preferred_password.present?
-        :sedex_com_contrato_1
+      if has_contract?
+	:sedex_com_contrato_6
       else
         :sedex
       end
@@ -14,9 +14,9 @@ module Spree
     
     def shipping_code
       if has_contract?
-        40096
+        '04162'
       else
-        40010
+        '40010'
       end
     end
   end

--- a/spree_correios.gemspec
+++ b/spree_correios.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_correios'
-  s.version     = '1.0.5'
+  s.version     = '1.0.6'
   s.summary     = %q{A spree extensions to add Brazil's Correio calculators}
   s.required_ruby_version = '>= 1.9.2'
 
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '>= 3.2.0'
-  s.add_dependency 'correios-frete', '~> 1.11.1'
+  s.add_dependency 'correios-frete', '1.12.0'
 
   s.add_development_dependency 'capybara', '1.0.1'
   s.add_development_dependency 'factory_girl'


### PR DESCRIPTION
Bump de versão da gem `spree_correios` por conta de upgrade nos códigos de serviço dos correios vindos da versão atualizada da gem `correios-frete`.